### PR TITLE
add privacy policy and TOS, easy debug mode for developers

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -91,9 +91,9 @@
     </h4>
     </br>
     <p>
-        <a href="https://draugeros.org/go/privacy" target="_blank">Privacy Policy</a>
+        <a href="{{ url_for('privacy') }}" target="_blank">Privacy Policy</a>
         </br>
-        <a href="https://draugeros.org/go/tos" target="_blank">Terms of Service</a>
+        <a href="{{ url_for('tos') }}" target="_blank">Terms of Service</a>
     </p>
 	</br>
 </footer>

--- a/website.py
+++ b/website.py
@@ -23,7 +23,9 @@
 #
 """Drauger OS website"""
 import flask
+import urllib3
 import wiki
+import sys
 
 APP = flask.Flask(__name__)
 
@@ -55,6 +57,8 @@ def convert_to_html_list(obj):
 
 
 @APP.route("/contact")
+@APP.route("/contact_us")
+@APP.route("/contact-us")
 def contact():
     """Cause I'm a nerd on multiple levels"""
     return flask.render_template("contact.html")
@@ -289,5 +293,33 @@ def wiki_post(title):
         return page_not_found()
 
 
+@APP.route("/privacy")
+def privacy():
+    """Provide the user with our privacy policy"""
+    http = urllib3.PoolManager()
+    # download markdown-formatted Privacy Policy from our GitHub
+    data = http.request("GET",
+                        "https://raw.githubusercontent.com/drauger-os-development/Policies-and-Operations-Manual/master/Privacy%20Policy.md").data
+    data = data.decode()
+    data = wiki.render_post(data)
+    return data
+
+
+@APP.route("/tos")
+def tos():
+    """Provide the user with our Terms of Service"""
+    http = urllib3.PoolManager()
+    # download markdown-formatted Terms of Service from our GitHub
+    data = http.request("GET",
+                        "https://raw.githubusercontent.com/drauger-os-development/Policies-and-Operations-Manual/master/Terms%20of%20Service.md").data
+    data = data.decode()
+    data = wiki.render_post(data)
+    return data
+
+
 if __name__ == "__main__":
-    APP.run(host="0.0.0.0", debug=False)
+    if ("--debug" in sys.argv) or ("-debug" in sys.argv) or ("-d" in sys.argv):
+        mode=True
+    else:
+        mode=False
+    APP.run(host="0.0.0.0", debug=mode)

--- a/wiki.py
+++ b/wiki.py
@@ -160,7 +160,7 @@ def get_raw_post(title):
 def get_isolated_post(title):
     """Get a post, outside of it's web page wrapper"""
     data = get_raw_post(title)
-    data["content"] = render_content(data["content"])
+    #  data["content"] = render_content(data["content"])
     return data
 
 
@@ -169,13 +169,13 @@ def render_post(content):
     content = content.split("\n")
     content[1] = "\n".join(content[1:])
     content = content[:2]
-    content[0] = content[0][4:-5]
+    content[0] = content[0][2:]
     post = render_template("wiki-post.html")
     post = post.split("{ title }")
     post.insert(1, content[0])
     post = "\n".join(post)
     post = post.split("{ content }")
-    post.insert(1, content[1])
+    post.insert(1, render_content(content[1]))
     content = "\n".join(post)
     return content
 


### PR DESCRIPTION
 * add links to privacy policy and TOS, the links adapt to point to the current domain, like on the menu. Helps with local testing and development, as well as the beta website
 * add easy access to `flask`'s debug mode for developers. Just run `website.py`, and pass it either `--debug`, `-debug`, or `-d` on the command line
 * reduce processing by parsing out titles for wiki pages faster and rendering less to HTML