### PR TITLE
Fix Torrent URL

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -52,7 +52,14 @@
     </div>
     <div class="centered">
         <p>Interested in trying out Drauger OS?</p>
-		<div><button class="downloadButton" onclick="window.location.href = 'https://download-optimizer.draugeros.org/ISOs/Drauger_OS-7.7-AMD64.iso'" class="download">Download&nbsp;<i class="fa-solid fa-download"></i></button>&nbsp;<button class="downloadButton" onclick="window.location.href = 'https://draugeros.org/assets/torrents/Drauger_OS-7.7-AMD64.iso.torrent'">Torrent&nbsp;<i class="fa-solid fa-file-arrow-down"></i></button></div>
+		<div>
+			<button class="downloadButton" onclick="window.location.href = 'https://download-optimizer.draugeros.org/ISOs/Drauger_OS-7.7-AMD64.iso'" class="download">Download&nbsp;<i class="fa-solid fa-download">
+			</i>
+			</button>&nbsp;
+			<button class="downloadButton" onclick="window.location.href = 'https://fosstorrents.com/thankyou/?name=drauger-os&cat=Current%20Edition&id=0&hybrid=0'">Torrent&nbsp;<i class="fa-solid fa-file-arrow-down">
+			</i>
+			</button>
+		</div>
 		<p>Download Info: 3.7GB | Ver. 7.7</p>
 		<p>For more info <a href="/download">Click Here</a>.</p>
     </div>


### PR DESCRIPTION
This fixes 2 bugs in 1 go:
 1. Currently, there is no Torrent file available to download Drauger OS. At least, from the Drauger OS website.
 2. When we did have a torrent, it was woefully out of date since it would need to be updated since we would update our ISO, and then a torrent would need to be released thereby meaning we need to replace the torrent file we distribute too.